### PR TITLE
Sending API key to backend now via x-api-key header. [closes #5]

### DIFF
--- a/packages/api/.env.development
+++ b/packages/api/.env.development
@@ -1,2 +1,0 @@
-HOST=host.docker.internal
-PORT=8080

--- a/packages/api/src/controllers/auth/auth.controller.ts
+++ b/packages/api/src/controllers/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post } from "@nestjs/common";
+import { Body, Controller, Get, Post, Query } from "@nestjs/common";
 
 import { AbstractAuthService } from "src/services/auth/abstract-auth.service";
 
@@ -6,11 +6,11 @@ import { AbstractAuthService } from "src/services/auth/abstract-auth.service";
 export class AuthController {
   constructor(private readonly authService: AbstractAuthService) {}
 
-  @Post("verify-api-key")
+  @Get("verify-api-key")
   public async verifyApiKey(
-    @Body() data: { apiKey: string }
+    @Query("api_key") api_key: string
   ): Promise<boolean> {
-    return this.authService.isApiKeyVerified(data.apiKey);
+    return this.authService.isApiKeyVerified(api_key);
   }
 
   @Get("fetch-api-credentials")

--- a/packages/api/src/middleware/api-key-verification.middleware.ts
+++ b/packages/api/src/middleware/api-key-verification.middleware.ts
@@ -1,0 +1,35 @@
+import { Injectable, NestMiddleware } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+
+import _ from "lodash";
+import { Request, Response, NextFunction } from "express";
+import { createHmac } from "crypto";
+
+import { HttpConstants } from "@/shared-core";
+
+import { EnvironmentVariables } from "src/constants/environment-variables";
+
+@Injectable()
+export class ApiKeyVerificationMiddleware implements NestMiddleware {
+  constructor(
+    private readonly configService: ConfigService<EnvironmentVariables>
+  ) {}
+
+  use(request: Request, response: Response, next: NextFunction) {
+    const hashedApiKey: string = createHmac(
+      "sha256",
+      this.configService.get<string>("API_KEY")
+    ).digest("hex");
+
+    if (
+      _.isEqual(hashedApiKey, request.headers[HttpConstants.API_KEY_HEADER])
+    ) {
+      next();
+    } else {
+      return response.status(403).json({
+        message:
+          "You are unauthorised to access this resource. You must provide a valid API_KEY.",
+      });
+    }
+  }
+}

--- a/packages/api/src/modules/app.module.ts
+++ b/packages/api/src/modules/app.module.ts
@@ -15,9 +15,7 @@ import { ChatsModule } from "./chats.module";
       isGlobal: true,
       expandVariables: true,
       cache: true,
-      envFilePath: !_.isEqual(process.env.NODE_ENV, "production")
-        ? [".env.local", ".env.development"]
-        : [],
+      envFilePath: ".env.local",
     }),
     ServeStaticModule.forRoot({
       rootPath: path.join(__dirname, "../../../../../", "client/dist"),

--- a/packages/api/src/modules/auth.module.ts
+++ b/packages/api/src/modules/auth.module.ts
@@ -1,7 +1,8 @@
-import { Module } from "@nestjs/common";
+import { Module, NestModule, MiddlewareConsumer } from "@nestjs/common";
 
 import { AuthController } from "src/controllers/auth/auth.controller";
 import { TelegramAuthController } from "src/controllers/auth/telegram-auth.controller";
+import { ApiKeyVerificationMiddleware } from "src/middleware/api-key-verification.middleware";
 import { AbstractAuthService } from "src/services/auth/abstract-auth.service";
 import { AbstractTelegramAuthService } from "src/services/auth/abstract-telegram-auth.service";
 import { AuthService } from "src/services/auth/auth.service";
@@ -23,4 +24,10 @@ import { ChatAutomationsModule } from "./chat-automation.module";
     },
   ],
 })
-export class AuthModule {}
+export class AuthModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(ApiKeyVerificationMiddleware)
+      .forRoutes(AuthController, TelegramAuthController);
+  }
+}

--- a/packages/api/src/modules/chat-automation.module.ts
+++ b/packages/api/src/modules/chat-automation.module.ts
@@ -1,6 +1,7 @@
-import { Module } from "@nestjs/common";
+import { Module, NestModule, MiddlewareConsumer } from "@nestjs/common";
 
 import { TelegramChatAutomationsController } from "src/controllers/chat-automations/telegram-chat-automations.controller";
+import { ApiKeyVerificationMiddleware } from "src/middleware/api-key-verification.middleware";
 import { AbstractTelegramChatAutomationsDaoService } from "src/services/chat-automations/abstract-telegram-chat-automations-dao.service";
 import { AbstractTelegramChatAutomationsHandlerService } from "src/services/chat-automations/abstract-telegram-chat-automations-handler.service";
 import { TelegramChatAutomationsDaoService } from "src/services/chat-automations/telegram-chat-automations-dao.service";
@@ -23,4 +24,10 @@ import { TelegramChatAutomationsHandlerService } from "src/services/chat-automat
     },
   ],
 })
-export class ChatAutomationsModule {}
+export class ChatAutomationsModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(ApiKeyVerificationMiddleware)
+      .forRoutes(TelegramChatAutomationsController);
+  }
+}

--- a/packages/api/src/modules/chats.module.ts
+++ b/packages/api/src/modules/chats.module.ts
@@ -1,9 +1,10 @@
-import { Module } from "@nestjs/common";
+import { Module, NestModule, MiddlewareConsumer } from "@nestjs/common";
 
+import { AuthModule } from "./auth.module";
 import { TelegramChatsController } from "src/controllers/chats/telegram-chats.controller";
+import { ApiKeyVerificationMiddleware } from "src/middleware/api-key-verification.middleware";
 import { AbstractChatsService } from "src/services/chats/abstract-chats.service";
 import { TelegramChatsService } from "src/services/chats/telegram-chats.service";
-import { AuthModule } from "./auth.module";
 
 @Module({
   imports: [AuthModule],
@@ -15,4 +16,10 @@ import { AuthModule } from "./auth.module";
     },
   ],
 })
-export class ChatsModule {}
+export class ChatsModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(ApiKeyVerificationMiddleware)
+      .forRoutes(TelegramChatsController);
+  }
+}

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -31,7 +31,7 @@ const telegramAuthService: ITelegramAuthService = new TelegramAuthService(
 );
 
 const telegramChatsService: ITelegramChatsService = new TelegramChatsService(
-  telegramAuthService as TelegramAuthService
+  httpService
 );
 
 const telegramChatsAutomationDaoService: ITelegramChatAutomationsDaoService =

--- a/packages/client/src/components/settings/telegram-account/SettingsTelegramAccountSetupCard.vue
+++ b/packages/client/src/components/settings/telegram-account/SettingsTelegramAccountSetupCard.vue
@@ -43,25 +43,15 @@ import { Store, useStore } from "vuex";
 import { VaCard, VaCardTitle, VaCardContent, VaButton } from "vuestic-ui";
 
 import { StoreStateType } from "@/store";
-import { ServiceProviderKeys } from "@/services/service-provider-keys";
 import SettingsTelegramAccountSetupCardConnectModal from "@/components/settings/telegram-account/SettingsTelegramAccountSetupCardConnectModal.vue";
-import { IHttpService } from "@/services/http/i-http.service";
-import { APIEndpoints } from "@/constants/api-endpoints";
 
 const store: Store<StoreStateType> = useStore();
-
-const httpService: IHttpService = inject(ServiceProviderKeys.HTTP_SERVICE);
 
 const isConnectedToTelegram = ref<boolean>(false);
 const showTelegramAccountSetupModal = ref<boolean>(false);
 const reconnectingToTelegram = ref<boolean>(false);
 
 async function onOpenTelegramAccountSetupModal(): Promise<void> {
-  // isConnectedToTelegram.value = await httpService.get(
-  //   APIEndpoints.TELEGRAM_AUTH_IS_AUTHORISED
-  // );
-
-  // reconnectingToTelegram.value = false;
   showTelegramAccountSetupModal.value = true;
 }
 

--- a/packages/client/src/pages/core/dashboard/DashboardPage.vue
+++ b/packages/client/src/pages/core/dashboard/DashboardPage.vue
@@ -67,13 +67,18 @@ import { ServiceProviderKeys } from "@/services/service-provider-keys";
 import { RoutePaths } from "@/constants/route-paths";
 import Navbar from "@/components/core/Navbar.vue";
 import Sidebar from "@/components/core/Sidebar.vue";
-import { IHttpService } from "@/services/http/i-http.service";
-import { APIEndpoints } from "@/constants/api-endpoints";
+import { ITelegramAuthService } from "@/services/telegram/auth/i-telegram-auth.service";
+import { ITelegramChatsService } from "@/services/telegram/chats/i-telegram-chats.service";
 
 const route: RouteLocationNormalizedLoaded = useRoute();
 const store: Store<StoreStateType> = useStore();
 
-const httpService: IHttpService = inject(ServiceProviderKeys.HTTP_SERVICE);
+const telegramAuthService: ITelegramAuthService = inject(
+  ServiceProviderKeys.TELEGRAM_AUTH_SERVICE
+);
+const telegramChatsService: ITelegramChatsService = inject(
+  ServiceProviderKeys.TELEGRAM_CHATS_SERVICE
+);
 
 const isLoggedIntoTelegramComputed = computed(
   () => store.state.telegramStore.isLoggedIn
@@ -93,9 +98,7 @@ async function initialise(): Promise<void> {
   try {
     isInitialisingTelegram.value = true;
 
-    const isAuthorised = await httpService.get(
-      APIEndpoints.TELEGRAM_AUTH_IS_AUTHORISED
-    );
+    const isAuthorised = await telegramAuthService.isAuthorised();
 
     await store.dispatch(
       TelegramStoreActions.UPDATE_IS_LOGGED_INTO_TELEGRAM,
@@ -111,7 +114,7 @@ async function initialise(): Promise<void> {
 
 async function fetchChats(): Promise<void> {
   try {
-    const chats = await httpService.get(APIEndpoints.CHATS);
+    const chats = await telegramChatsService.getAll();
     await store.dispatch(TelegramStoreActions.UPDATE_TELEGRAM_CHATS, chats);
   } catch (error) {
     LoggerUtils.error("DashboardPage", "fetchChats", error);

--- a/packages/client/src/router/guards/auth/auth.guard.ts
+++ b/packages/client/src/router/guards/auth/auth.guard.ts
@@ -8,6 +8,8 @@ import _ from "lodash";
 
 import { LoggerUtils } from "@shared-core";
 
+import store, { StoreStateType } from "@/store";
+import { AuthStoreActions } from "@/store/modules/auth.store";
 import { RoutePaths } from "@/constants/route-paths";
 import { LocalStorageService } from "@/services/storage/local-storage.service";
 import { LocalStorageKeys } from "@/constants/local-storage-keys";
@@ -25,6 +27,10 @@ const authRouteGuard = async (
     const apiKey = await LocalStorageService.getItem<string>(
       LocalStorageKeys.API_KEY
     );
+
+    if (!_.isNil(apiKey)) {
+      await store.dispatch(AuthStoreActions.SET_API_KEY, apiKey);
+    }
 
     const isUserAuthorised: boolean = !_.isEmpty(apiKey);
 

--- a/packages/client/src/services/auth/auth.service.ts
+++ b/packages/client/src/services/auth/auth.service.ts
@@ -16,13 +16,14 @@ export class AuthService implements IAuthService {
     try {
       const hashedApiKey: string = createHmac("sha256", apiKey).digest("hex");
 
-      const isApiKeyVerified = await this.httpService.get<{
-        apiKey: string;
-      }>(`${APIEndpoints.AUTH_VERIFY_API_KEY}?api_key=${apiKey}`, {
-        headers: {
-          [HttpConstants.API_KEY_HEADER]: apiKey,
-        },
-      });
+      const isApiKeyVerified = await this.httpService.get<boolean>(
+        `${APIEndpoints.AUTH_VERIFY_API_KEY}?api_key=${hashedApiKey}`,
+        {
+          headers: {
+            [HttpConstants.API_KEY_HEADER]: hashedApiKey,
+          },
+        }
+      );
 
       if (isApiKeyVerified) {
         await LocalStorageService.setItem(

--- a/packages/client/src/services/auth/auth.service.ts
+++ b/packages/client/src/services/auth/auth.service.ts
@@ -1,13 +1,13 @@
 import _ from "lodash";
 import { createHmac } from "crypto";
 
-import { LoggerUtils } from "@shared-core";
+import { LoggerUtils, HttpConstants } from "@shared-core";
 
+import { LocalStorageKeys } from "@/constants/local-storage-keys";
+import { APIEndpoints } from "@/constants/api-endpoints";
 import { LocalStorageService } from "../storage/local-storage.service";
 import { IAuthService } from "./i-auth.service";
-import { LocalStorageKeys } from "@/constants/local-storage-keys";
 import { IHttpService } from "../http/i-http.service";
-import { APIEndpoints } from "@/constants/api-endpoints";
 
 export class AuthService implements IAuthService {
   constructor(private readonly httpService: IHttpService) {}
@@ -16,10 +16,12 @@ export class AuthService implements IAuthService {
     try {
       const hashedApiKey: string = createHmac("sha256", apiKey).digest("hex");
 
-      const isApiKeyVerified = await this.httpService.post<{
+      const isApiKeyVerified = await this.httpService.get<{
         apiKey: string;
-      }>(APIEndpoints.AUTH_VERIFY_API_KEY, {
-        apiKey: hashedApiKey,
+      }>(`${APIEndpoints.AUTH_VERIFY_API_KEY}?api_key=${apiKey}`, {
+        headers: {
+          [HttpConstants.API_KEY_HEADER]: apiKey,
+        },
       });
 
       if (isApiKeyVerified) {
@@ -30,7 +32,7 @@ export class AuthService implements IAuthService {
 
         return Promise.resolve(true);
       } else {
-        return Promise.reject({ message: "API key is invalid" });
+        return Promise.reject({ message: "API_KEY is invalid" });
       }
     } catch (error) {
       LoggerUtils.error("AuthService", "signIn", error);

--- a/packages/client/src/services/http/axios-http.service.ts
+++ b/packages/client/src/services/http/axios-http.service.ts
@@ -1,6 +1,9 @@
-import axios from "axios";
+import axios, { AxiosRequestConfig } from "axios";
 import _ from "lodash";
 
+import { LoggerUtils } from "../../../../shared-core/src/helpers";
+import { LocalStorageService } from "../storage/local-storage.service";
+import { LocalStorageKeys } from "@/constants/local-storage-keys";
 import { IHttpService } from "./i-http.service";
 
 export class AxiosHttpService implements IHttpService {
@@ -16,33 +19,57 @@ export class AxiosHttpService implements IHttpService {
     }
   }
 
-  public async get<T>(url: string): Promise<T> {
-    console.log(`${this.apiUrl}/${url}`);
-
-    return axios.get(`${this.apiUrl}/${url}`).then((response) => response.data);
-  }
-
-  public async post<T>(url: string, data: T): Promise<any> {
-    console.log(`${this.apiUrl}/${url}`);
-
+  public async get<T>(
+    url: string,
+    options?: AxiosRequestConfig<any>
+  ): Promise<T> {
     return axios
-      .post<T>(`${this.apiUrl}/${url}`, data)
+      .get(`${this.apiUrl}/${url}`, options)
       .then((response) => response.data);
   }
 
-  public async put<T>(url: string, data: T): Promise<any> {
-    console.log(`${this.apiUrl}/${url}`);
-
+  public async post<T>(
+    url: string,
+    data: T,
+    options?: AxiosRequestConfig<any>
+  ): Promise<any> {
     return axios
-      .put<T>(`${this.apiUrl}/${url}`, data)
+      .post<T>(`${this.apiUrl}/${url}`, data, options)
       .then((response) => response.data);
   }
 
-  public async delete(url: string): Promise<any> {
-    console.log(`${this.apiUrl}/${url}`);
-
+  public async put<T>(
+    url: string,
+    data: T,
+    options?: AxiosRequestConfig<any>
+  ): Promise<any> {
     return axios
-      .delete(`${this.apiUrl}/${url}`)
+      .put<T>(`${this.apiUrl}/${url}`, data, options)
       .then((response) => response.data);
   }
+
+  public async delete(
+    url: string,
+    options?: AxiosRequestConfig<any>
+  ): Promise<any> {
+    return axios
+      .delete(`${this.apiUrl}/${url}`, options)
+      .then((response) => response.data);
+  }
+
+  // public async getApiKeyFromLocalStorage(): Promise<string> {
+  //   try {
+  //     if (_.isEmpty(this.apiKey)) {
+  //       const hashedApiKey = await LocalStorageService.getItem<string>(
+  //         LocalStorageKeys.API_KEY
+  //       );
+
+  //       this.apiKey = hashedApiKey;
+  //     }
+  //   } catch (error) {
+  //     LoggerUtils.error("AxiosHttpService", "getApiKeyFromLocalStorage", error);
+  //   }
+
+  //   return this.apiKey;
+  // }
 }

--- a/packages/client/src/services/http/axios-http.service.ts
+++ b/packages/client/src/services/http/axios-http.service.ts
@@ -1,9 +1,6 @@
 import axios, { AxiosRequestConfig } from "axios";
 import _ from "lodash";
 
-import { LoggerUtils } from "../../../../shared-core/src/helpers";
-import { LocalStorageService } from "../storage/local-storage.service";
-import { LocalStorageKeys } from "@/constants/local-storage-keys";
 import { IHttpService } from "./i-http.service";
 
 export class AxiosHttpService implements IHttpService {
@@ -56,20 +53,4 @@ export class AxiosHttpService implements IHttpService {
       .delete(`${this.apiUrl}/${url}`, options)
       .then((response) => response.data);
   }
-
-  // public async getApiKeyFromLocalStorage(): Promise<string> {
-  //   try {
-  //     if (_.isEmpty(this.apiKey)) {
-  //       const hashedApiKey = await LocalStorageService.getItem<string>(
-  //         LocalStorageKeys.API_KEY
-  //       );
-
-  //       this.apiKey = hashedApiKey;
-  //     }
-  //   } catch (error) {
-  //     LoggerUtils.error("AxiosHttpService", "getApiKeyFromLocalStorage", error);
-  //   }
-
-  //   return this.apiKey;
-  // }
 }

--- a/packages/client/src/services/http/i-http.service.ts
+++ b/packages/client/src/services/http/i-http.service.ts
@@ -1,6 +1,10 @@
+export type IHttpRequestConfig = {
+  headers: Record<string, string>;
+};
+
 export interface IHttpService {
-  get<T>(url: string): Promise<T>;
-  post<T>(url: string, data: T): Promise<any>;
-  put<T>(url: string, data: T): Promise<any>;
-  delete(url: string): Promise<any>;
+  get<T>(url: string, options?: IHttpRequestConfig): Promise<T>;
+  post<T>(url: string, data: T, options?: IHttpRequestConfig): Promise<any>;
+  put<T>(url: string, data: T, options?: IHttpRequestConfig): Promise<any>;
+  delete(url: string, options?: IHttpRequestConfig): Promise<any>;
 }

--- a/packages/client/src/services/telegram/auth/i-telegram-auth.service.ts
+++ b/packages/client/src/services/telegram/auth/i-telegram-auth.service.ts
@@ -1,70 +1,15 @@
-export type SentCodeResultType = {
-  phoneCodeHash: string;
-};
+import { SentCodeResultType, SignInResultType } from "@shared-core";
 
-export type SignInResultType = {
-  passwordHint?: string;
-  isPasswordRequired: boolean;
-};
-
-/**
- * An interface for implementing telegram authentication.
- */
 export interface ITelegramAuthService {
-  /**
-   * Sets up and initialises the service.
-   * @returns {Promise<void>} promise void
-   */
-  initialise(): Promise<void>;
+  isAuthorised(): Promise<boolean>;
 
-  /**
-   * Sends an auth code to the user's telegram account.
-   * @param {string} phoneNumber
-   * @returns {Promise<SentCodeResultType>} the result from sending the auth code.
-   */
   sendCode(phoneNumber: string): Promise<SentCodeResultType>;
 
-  /**
-   * Signs in the user to their telegram account.
-   * @param {string} phoneNumber
-   * @param {string} phoneCodeHash
-   * @param {string} phoneCode
-   * @returns {Promise<SignInResultType>} the result from signing in.
-   */
   signIn(
     phoneNumber: string,
     phoneCodeHash: string,
     phoneCode: string
   ): Promise<SignInResultType>;
 
-  /**
-   * Signs in the user to their telegram account with their 2FA password.
-   * @param {string} password
-   * @returns {Promise<any>} the result from signing in with their 2FA password.
-   */
   signInWithTwoFactorPassword(password: string): Promise<any>;
-
-  /**
-   * Gets the telegram client used in this service.
-   * @returns {any} the client instance.
-   */
-  getClient(): any;
-
-  /**
-   * Checks whether the telegram client is connected.
-   * @returns {Promise<boolean>} promise boolean.
-   */
-  isConnected(): Promise<boolean>;
-
-  /**
-   * Checks whether the current user is logged in and authorised to use the telegram API.
-   * @returns {Promise<boolean>} promise boolean.
-   */
-  isAuthorised(): Promise<boolean>;
-
-  /**
-   * Executes any cleanup operations needed for this service.
-   * @returns {Promise<void>} promise void.
-   */
-  disconnect(): Promise<void>;
 }

--- a/packages/client/src/services/telegram/auth/telegram-auth.service.ts
+++ b/packages/client/src/services/telegram/auth/telegram-auth.service.ts
@@ -1,87 +1,45 @@
 import _ from "lodash";
-import { Api, TelegramClient } from "telegram";
-import { StringSession } from "telegram/sessions";
 
-import { LoggerUtils, RegexUtils } from "@shared-core";
-
-import { LocalStorageKeys } from "@/constants/local-storage-keys";
-import { LocalStorageService } from "../../storage/local-storage.service";
 import {
-  ITelegramAuthService,
+  HttpConstants,
+  LoggerUtils,
   SentCodeResultType,
   SignInResultType,
-} from "./i-telegram-auth.service";
+} from "@shared-core";
+
+import store, { StoreStateType } from "@/store";
+import { ITelegramAuthService } from "./i-telegram-auth.service";
 import { IHttpService } from "@/services/http/i-http.service";
 import { APIEndpoints } from "@/constants/api-endpoints";
 
 export class TelegramAuthService implements ITelegramAuthService {
-  private apiId: number;
-  private apiHash: string;
-  private stringSession: StringSession;
-
-  private client: TelegramClient;
-
   constructor(private readonly httpService: IHttpService) {}
 
-  public async initialise(): Promise<void> {
-    try {
-      const { apiId, apiHash } = await this.httpService.get(
-        APIEndpoints.AUTH_FETCH_API_CREDENTIALS
-      );
-
-      this.apiId = parseInt(apiId);
-      this.apiHash = apiHash;
-
-      const savedSessionString: string = await this.loadSessionString();
-      this.stringSession = new StringSession(savedSessionString);
-      await this.stringSession.load();
-
-      this.client = new TelegramClient(
-        this.stringSession,
-        this.apiId,
-        this.apiHash,
-        {
-          connectionRetries: 3,
-        }
-      );
-
-      await this.client.connect();
-    } catch (error) {
-      LoggerUtils.error("TelegramAuthService", "initialise", error);
-    }
-  }
-
-  private async loadSessionString(): Promise<string> {
-    try {
-      const savedTelegramSession: string =
-        await LocalStorageService.getItem<string>(
-          LocalStorageKeys.SAVED_TELEGRAM_SESSION
-        );
-
-      return !_.isNil(savedTelegramSession)
-        ? Promise.resolve(savedTelegramSession)
-        : Promise.resolve("");
-    } catch (error) {
-      LoggerUtils.error("TelegramAuthService", "loadSessionString", error);
-    }
+  public async isAuthorised(): Promise<boolean> {
+    return this.httpService.get(APIEndpoints.TELEGRAM_AUTH_IS_AUTHORISED, {
+      headers: {
+        [HttpConstants.API_KEY_HEADER]: (store.state as StoreStateType)
+          .authStore.apiKey,
+      },
+    });
   }
 
   public async sendCode(phoneNumber: string): Promise<SentCodeResultType> {
     try {
-      const { phoneCodeHash }: Api.auth.SentCode = await this.client.invoke(
-        new Api.auth.SendCode({
-          apiId: this.apiId,
-          apiHash: this.apiHash,
+      const data: { phoneCodeHash: string } = await this.httpService.post(
+        APIEndpoints.TELEGRAM_AUTH_SEND_CODE,
+        {
           phoneNumber,
-          settings: new Api.CodeSettings({
-            allowFlashcall: true,
-            currentNumber: true,
-            allowAppHash: true,
-          }),
-        })
+        },
+        {
+          headers: {
+            [HttpConstants.API_KEY_HEADER]: (store.state as StoreStateType)
+              .authStore.apiKey,
+          },
+        }
       );
 
-      return Promise.resolve({ phoneCodeHash });
+      return Promise.resolve({ phoneCodeHash: data.phoneCodeHash });
     } catch (error) {
       LoggerUtils.error("TelegramAuthService", "sendCode", error);
 
@@ -95,98 +53,51 @@ export class TelegramAuthService implements ITelegramAuthService {
     phoneCode: string
   ): Promise<SignInResultType> {
     try {
-      if (_.isEqual(phoneCode.length, 5)) {
-        if (RegexUtils.isDigitsOnly(phoneCode)) {
-          await this.client.invoke(
-            new Api.auth.SignIn({ phoneNumber, phoneCodeHash, phoneCode })
-          );
-
-          await LocalStorageService.setItem(
-            LocalStorageKeys.SAVED_TELEGRAM_SESSION,
-            this.stringSession.save()
-          );
-
-          return Promise.resolve({ isPasswordRequired: false });
-        } else {
-          return Promise.reject({ message: "Code must be digits only." });
+      const { isPasswordRequired } = await this.httpService.post(
+        APIEndpoints.TELEGRAM_AUTH_SIGN_IN,
+        {
+          phoneNumber,
+          phoneCodeHash,
+          phoneCode,
+        },
+        {
+          headers: {
+            [HttpConstants.API_KEY_HEADER]: (store.state as StoreStateType)
+              .authStore.apiKey,
+          },
         }
-      } else {
-        return Promise.reject({ message: "Code must be 5 digits." });
-      }
-    } catch (error) {
-      if (_.isEqual(error.errorMessage, "SESSION_PASSWORD_NEEDED")) {
-        return Promise.resolve({ isPasswordRequired: true });
-      } else {
-        LoggerUtils.error("TelegramAuthService", "signIn", error);
+      );
 
-        throw new Error("AUTH_USER_CANCEL");
-      }
+      return Promise.resolve({ isPasswordRequired });
+    } catch (error) {
+      LoggerUtils.error("TelegramAuthService", "signIn", error);
+
+      return Promise.reject(error);
     }
   }
 
   public async signInWithTwoFactorPassword(password: string): Promise<any> {
     try {
-      await this.client.signInWithPassword(
+      await this.httpService.post(
+        APIEndpoints.TELEGRAM_AUTH_SIGN_IN_WITH_TWO_FACTOR,
         {
-          apiId: this.apiId,
-          apiHash: this.apiHash,
+          password,
         },
         {
-          password: () => {
-            return Promise.resolve(password);
+          headers: {
+            [HttpConstants.API_KEY_HEADER]: (store.state as StoreStateType)
+              .authStore.apiKey,
           },
-          onError: (error: any) =>
-            LoggerUtils.error(
-              "TelegramAuthService",
-              "signInWithTwoFactorPassword",
-              error
-            ),
         }
       );
 
-      await LocalStorageService.setItem(
-        LocalStorageKeys.SAVED_TELEGRAM_SESSION,
-        this.stringSession.save()
-      );
+      return Promise.resolve();
     } catch (error) {
       LoggerUtils.error(
         "TelegramAuthService",
         "signInWithTwoFactorPassword",
         error
       );
-
-      return Promise.reject(error);
-    }
-  }
-
-  public getClient(): TelegramClient {
-    return this.client;
-  }
-
-  public async isConnected(): Promise<boolean> {
-    return Promise.resolve(this.client.connected);
-  }
-
-  public async isAuthorised(): Promise<boolean> {
-    try {
-      const authorised = await this.client.checkAuthorization();
-
-      return Promise.resolve(authorised);
-    } catch (error) {
-      LoggerUtils.error("TelegramAuthService", "isAuthorised", error);
-
-      return Promise.reject(error);
-    }
-  }
-
-  public async disconnect(): Promise<void> {
-    try {
-      await LocalStorageService.removeItem(
-        LocalStorageKeys.SAVED_TELEGRAM_SESSION
-      );
-      await this.client.disconnect();
-    } catch (error) {
-      LoggerUtils.error("TelegramAuthService", "disconnect", error);
 
       return Promise.reject(error);
     }

--- a/packages/client/src/services/telegram/chats/api-telegram-chat-automations-dao.service.ts
+++ b/packages/client/src/services/telegram/chats/api-telegram-chat-automations-dao.service.ts
@@ -1,6 +1,6 @@
-import { ChatAutomation, LoggerUtils } from "@shared-core";
+import { ChatAutomation, HttpConstants, LoggerUtils } from "@shared-core";
 
-import store from "@/store";
+import store, { StoreStateType } from "@/store";
 import { APIEndpoints } from "@/constants/api-endpoints";
 import { IHttpService } from "@/services/http/i-http.service";
 import {
@@ -17,7 +17,13 @@ export class ApiTelegramChatAutomationsDaoService
   public async create(): Promise<ChatAutomationCreatedResultType> {
     try {
       const { id } = await this.httpService.get<{ id: string }>(
-        APIEndpoints.CHAT_AUTOMATIONS_CREATE
+        APIEndpoints.CHAT_AUTOMATIONS_CREATE,
+        {
+          headers: {
+            [HttpConstants.API_KEY_HEADER]: (store.state as StoreStateType)
+              .authStore.apiKey,
+          },
+        }
       );
 
       await this.getAll();
@@ -38,7 +44,13 @@ export class ApiTelegramChatAutomationsDaoService
 
   public async getAll(): Promise<ChatAutomation[]> {
     const chatAutomations = await this.httpService.get<ChatAutomation[]>(
-      APIEndpoints.CHAT_AUTOMATIONS
+      APIEndpoints.CHAT_AUTOMATIONS,
+      {
+        headers: {
+          [HttpConstants.API_KEY_HEADER]: (store.state as StoreStateType)
+            .authStore.apiKey,
+        },
+      }
     );
 
     await store.dispatch(
@@ -50,7 +62,12 @@ export class ApiTelegramChatAutomationsDaoService
   }
 
   public async getOne(id: string): Promise<ChatAutomation> {
-    return this.httpService.get(`${APIEndpoints.CHAT_AUTOMATIONS}/${id}`);
+    return this.httpService.get(`${APIEndpoints.CHAT_AUTOMATIONS}/${id}`, {
+      headers: {
+        [HttpConstants.API_KEY_HEADER]: (store.state as StoreStateType)
+          .authStore.apiKey,
+      },
+    });
   }
 
   public async update(
@@ -59,11 +76,22 @@ export class ApiTelegramChatAutomationsDaoService
   ): Promise<void> {
     return this.httpService.put(
       `${APIEndpoints.CHAT_AUTOMATIONS}/${id}`,
-      chatAutomation
+      chatAutomation,
+      {
+        headers: {
+          [HttpConstants.API_KEY_HEADER]: (store.state as StoreStateType)
+            .authStore.apiKey,
+        },
+      }
     );
   }
 
   public async delete(id: string): Promise<void> {
-    return this.httpService.delete(`${APIEndpoints.CHAT_AUTOMATIONS}/${id}`);
+    return this.httpService.delete(`${APIEndpoints.CHAT_AUTOMATIONS}/${id}`, {
+      headers: {
+        [HttpConstants.API_KEY_HEADER]: (store.state as StoreStateType)
+          .authStore.apiKey,
+      },
+    });
   }
 }

--- a/packages/client/src/services/telegram/chats/i-telegram-chats.service.ts
+++ b/packages/client/src/services/telegram/chats/i-telegram-chats.service.ts
@@ -1,10 +1,3 @@
-/**
- * An interface for interacting with the Telegram API for all Chat related activities.
- */
 export interface ITelegramChatsService {
-  /**
-   * Gets all telegram chats
-   * @returns {Promise<any[]>} All the chats
-   */
-  getAllChats(): Promise<any[]>;
+  getAll(): Promise<any[]>;
 }

--- a/packages/client/src/services/telegram/chats/telegram-chats.service.ts
+++ b/packages/client/src/services/telegram/chats/telegram-chats.service.ts
@@ -1,36 +1,21 @@
 import { Api } from "telegram";
 
-import { LoggerUtils } from "@shared-core";
+import { HttpConstants } from "@shared-core";
 
-import { TelegramAuthService } from "../auth/telegram-auth.service";
+import store, { StoreStateType } from "@/store";
 import { ITelegramChatsService } from "./i-telegram-chats.service";
-
-import testChatsAsJson from "./test-chats.json";
+import { IHttpService } from "@/services/http/i-http.service";
+import { APIEndpoints } from "@/constants/api-endpoints";
 
 export class TelegramChatsService implements ITelegramChatsService {
-  constructor(private readonly telegramAuthService: TelegramAuthService) {}
+  constructor(private readonly httpService: IHttpService) {}
 
-  public async getAllChats(): Promise<Api.TypeChat[]> {
-    try {
-      // const client = this.telegramAuthService.getClient();
-
-      // const chatResults: Api.messages.TypeChats = await client.invoke(
-      //   new Api.messages.GetAllChats({ exceptIds: [] })
-      // );
-
-      // const chats = chatResults.chats;
-      // return Promise.resolve(chats);
-
-      return this.useTestChats();
-    } catch (error) {
-      LoggerUtils.error("TelegramChatsService", "getAllChats", error);
-
-      return Promise.reject(error.message);
-    }
-  }
-
-  // TODO: using for testing purposes
-  private useTestChats(): Promise<any> {
-    return Promise.resolve(testChatsAsJson);
+  public async getAll(): Promise<Api.TypeChat[]> {
+    return this.httpService.get(APIEndpoints.CHATS, {
+      headers: {
+        [HttpConstants.API_KEY_HEADER]: (store.state as StoreStateType)
+          .authStore.apiKey,
+      },
+    });
   }
 }

--- a/packages/client/src/services/telegram/settings/i-telegram-settings.service.ts
+++ b/packages/client/src/services/telegram/settings/i-telegram-settings.service.ts
@@ -1,0 +1,1 @@
+export interface ITelegramSettingsService {}

--- a/packages/client/src/store/index.ts
+++ b/packages/client/src/store/index.ts
@@ -2,6 +2,7 @@ import { createLogger, createStore } from "vuex";
 
 import _ from "lodash";
 
+import authStore, { AuthStoreStateType } from "./modules/auth.store";
 import telegramStore, {
   TelegramStoreStateType,
 } from "./modules/telegram.store";
@@ -10,6 +11,7 @@ import userStore, { UserStoreStateType } from "./modules/user.store";
 const debugModeEnabled = !_.isEqual(process.env.NODE_ENV, "production");
 
 export type StoreStateType = {
+  authStore: AuthStoreStateType;
   telegramStore: TelegramStoreStateType;
   userStore: UserStoreStateType;
 };
@@ -17,5 +19,5 @@ export type StoreStateType = {
 export default createStore({
   strict: debugModeEnabled,
   plugins: debugModeEnabled ? [createLogger()] : [],
-  modules: { telegramStore, userStore },
+  modules: { authStore, telegramStore, userStore },
 });

--- a/packages/client/src/store/modules/auth.store.ts
+++ b/packages/client/src/store/modules/auth.store.ts
@@ -1,0 +1,39 @@
+export type AuthStoreStateType = {
+  apiKey: string;
+};
+
+const state: AuthStoreStateType = {
+  apiKey: "",
+};
+
+enum AuthStoreActionTypes {
+  SET_API_KEY = "SET_API_KEY",
+}
+
+const mutations = {
+  [AuthStoreActionTypes.SET_API_KEY](
+    state: AuthStoreStateType,
+    apiKey: string
+  ): void {
+    state.apiKey = apiKey;
+  },
+};
+
+const actions = {
+  [AuthStoreActionTypes.SET_API_KEY]: ({ commit }, apiKey: string): void => {
+    commit(AuthStoreActionTypes.SET_API_KEY, apiKey);
+  },
+};
+
+const storeKey = "authStore";
+
+export const AuthStoreActions = {
+  [AuthStoreActionTypes.SET_API_KEY]: `${storeKey}/${AuthStoreActionTypes.SET_API_KEY}`,
+};
+
+export default {
+  namespaced: true,
+  state,
+  mutations,
+  actions,
+};

--- a/packages/shared-core/src/models/http/http-constants.ts
+++ b/packages/shared-core/src/models/http/http-constants.ts
@@ -1,0 +1,3 @@
+export enum HttpConstants {
+  API_KEY_HEADER = "x-api-key",
+}

--- a/packages/shared-core/src/models/index.ts
+++ b/packages/shared-core/src/models/index.ts
@@ -7,3 +7,4 @@ export * from "./mail/mail-data.model";
 export * from "./telegram/chat-automation.model";
 export * from "./telegram/telegram-account-details.model";
 export * from "./telegram/telegram-auth-types";
+export * from "./http/http-constants";


### PR DESCRIPTION
…rs. Instead of making http requests via the components directly, we need to refactor the code so we use services instead and have the services do the http requests. This way we keep the code modular and give responsibility to the services instead. The services need to fetch the api key from local storage and send that via the headers using the x-api-key header.